### PR TITLE
Fixed the problem that occurs when using multiple plug-ins

### DIFF
--- a/src/__tests__/__snapshots__/basic.test.ts.snap
+++ b/src/__tests__/__snapshots__/basic.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`addUDFHelper basic declaration 1`] = `"function _declaration() { console.log(\\"declaration\\"); }"`;
 
 exports[`addUDFHelper basic dependencies 1`] = `
-"function _dependencies() { cild1() || _child2(); }
+"function _dependencies() { _child() || _child2(); }
 
 ;
 
@@ -15,7 +15,25 @@ function _grandchild() { return \\"grandchild\\"; }
 
 ;
 
-function _child() { return \\"child1\\"; }
+function _child() { return \\"child\\"; }
+
+;"
+`;
+
+exports[`addUDFHelper basic multi plugins 1`] = `
+"function _dependencies() { _child() || _child2(); }
+
+;
+
+function _child2() { _grandchild(); }
+
+;
+
+function _grandchild() { return \\"grandchild\\"; }
+
+;
+
+function _child() { return \\"child\\"; }
 
 ;"
 `;

--- a/src/__tests__/__snapshots__/error.test.ts.snap
+++ b/src/__tests__/__snapshots__/error.test.ts.snap
@@ -36,19 +36,3 @@ Please see the official documentation.
 https://babeljs.io/docs/en/babel-helpers
 "
 `;
-
-exports[`addUDFHelper error core_ext babelImplemented PluginPass#addUDFHelper 1`] = `
-"unknown: 
-This tool cannot be used. officially supported.
-Please see the official documentation.
-https://babeljs.io/docs/en/babel-helpers
-"
-`;
-
-exports[`addUDFHelper error core_ext babelImplemented PluginPass#listUDFHelper 1`] = `
-"unknown: 
-This tool cannot be used. officially supported.
-Please see the official documentation.
-https://babeljs.io/docs/en/babel-helpers
-"
-`;

--- a/src/__tests__/basic.test.ts
+++ b/src/__tests__/basic.test.ts
@@ -23,8 +23,8 @@ describe('addUDFHelper', () => {
       test(dir, () => {
         const helpers = require(inputFixturePath([type, dir]));
         // @ts-ignore
-        const programFunc = (pass) => pass.addUDFHelper(dir);
-        const code = printer({ helpers, programFunc });
+        const programFuncs = [(pass) => pass.addUDFHelper(dir)];
+        const code = printer({ helpers, programFuncs });
 
         expect(code).toMatchSnapshot();
         writeFile(outputFixturePath([type, dir]), code || '', () => {});
@@ -35,9 +35,9 @@ describe('addUDFHelper', () => {
       const dir = 'rename';
       const helpers = require(inputFixturePath([type, dir]));
       const content = `function _rename() { return "path.replaceWith" }`;
-      const programFunc = (pass) => pass.addUDFHelper(dir);
+      const programFuncs = [(pass) => pass.addUDFHelper(dir)];
       // @ts-ignore
-      const code = printer({ content, helpers, programFunc });
+      const code = printer({ content, helpers, programFuncs });
 
       expect(code).toMatchSnapshot();
       writeFile(outputFixturePath([type, dir]), code || '', () => {});
@@ -52,12 +52,10 @@ describe('listUDFHelper', () => {
     test('officialMix', () => {
       const dir = 'officialMix';
       const helpers = require(inputFixturePath([type, dir]));
-      const programFunc = (pass) => {
-        console.log(pass.listUDFHelper());
-      };
+      const programFuncs = [(pass) => console.log(pass.listUDFHelper())];
 
       // @ts-ignore
-      printer({ helpers, programFunc });
+      printer({ helpers, programFuncs });
       expect((console.log as jest.Mock).mock.calls[0][0]).toMatchSnapshot();
     });
   });

--- a/src/__tests__/basic.test.ts
+++ b/src/__tests__/basic.test.ts
@@ -27,7 +27,7 @@ describe('addUDFHelper', () => {
         const code = printer({ helpers, programFuncs });
 
         expect(code).toMatchSnapshot();
-        writeFile(outputFixturePath([type, dir]), code || '', () => {});
+        writeFile(outputFixturePath([type, dir]), code || '', () => { });
       });
     }
 
@@ -41,6 +41,17 @@ describe('addUDFHelper', () => {
 
       expect(code).toMatchSnapshot();
       writeFile(outputFixturePath([type, dir]), code || '', () => {});
+    });
+
+    test('multi plugins', () => {
+      const dir = 'dependencies';
+      const helpers = require(inputFixturePath([type, dir]));
+      const programFuncs = [(pass) => pass.addUDFHelper(dir)];
+      // @ts-ignore
+      const code = printer({ helpers, programFuncs });
+
+      expect(code).toMatchSnapshot();
+      writeFile(outputFixturePath([type, dir]), code || '', () => { });
     });
   });
 });

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -77,39 +77,39 @@ describe('addUDFHelper', () => {
           test(method, () => {
             const dir = 'declaration';
             const helpers = require(inputFixturePath(['basic', dir]));
-            const programFunc = (pass) => pass.addUDFHelper('declaration');
+            const programFuncs = [(pass) => pass.addUDFHelper('declaration')];
 
             // prettier-ignore
-            expect(() => { printer({ helpers, programFunc, preFunc }); }).toThrowError(new AlreadyImplementedError(
+            expect(() => { printer({ helpers, programFuncs, preFunc }); }).toThrowError(new AlreadyImplementedError(
               `unknown:\
  \nThis tool cannot be used. officially supported.
 Please see the official documentation.
 https://babeljs.io/docs/en/babel-helpers
 `));
             // prettier-ignore
-            expect(() => { printer({ helpers, programFunc, preFunc }); }).toThrowErrorMatchingSnapshot();
+            expect(() => { printer({ helpers, programFuncs, preFunc }); }).toThrowErrorMatchingSnapshot();
           });
         }
       });
 
       test('Not found UDF helpers', () => {
-        const programFunc = (pass) => pass.addUDFHelper('objectWithoutProperties');
+        const programFuncs = [(pass) => pass.addUDFHelper('objectWithoutProperties')];
 
         // prettier-ignore
-        expect(() => { printer({ programFunc } as any); }).toThrowError(new NotFoundError('unknown: Not found UDF helpers.'));
+        expect(() => { printer({ programFuncs } as any); }).toThrowError(new NotFoundError('unknown: Not found UDF helpers.'));
         // prettier-ignore
-        expect(() => { printer({ programFunc } as any); }).toThrowErrorMatchingSnapshot();
+        expect(() => { printer({ programFuncs } as any); }).toThrowErrorMatchingSnapshot();
       });
 
       test('babelAlreadyDefined', () => {
         const dir = 'babelAlreadyDefined';
         const helpers = require(inputFixturePath([type, dir]));
-        const programFunc = (pass) => pass.addUDFHelper('objectWithoutProperties');
+        const programFuncs = [(pass) => pass.addUDFHelper('objectWithoutProperties')];
 
         // prettier-ignore
-        expect(() => { printer({ helpers, programFunc }); }).toThrowError(new AlreadyImplementedError('unknown: objectWithoutProperties cannot be used because it is supported by babel official.\nPlease change the name of the helper.'));
+        expect(() => { printer({ helpers, programFuncs }); }).toThrowError(new AlreadyImplementedError('unknown: objectWithoutProperties cannot be used because it is supported by babel official.\nPlease change the name of the helper.'));
         // prettier-ignore
-        expect(() => { printer({ helpers, programFunc }); }).toThrowErrorMatchingSnapshot();
+        expect(() => { printer({ helpers, programFuncs }); }).toThrowErrorMatchingSnapshot();
       });
     });
 
@@ -130,12 +130,12 @@ https://babeljs.io/docs/en/babel-helpers
 
         test(dir, () => {
           const helpers = require(inputFixturePath([type, dir]));
-          const programFunc = (pass) => pass.addUDFHelper(dir);
+          const programFuncs = [(pass) => pass.addUDFHelper(dir)];
 
           // prettier-ignore
-          expect(() => { printer({ helpers, programFunc }); }).toThrowError(err);
+          expect(() => { printer({ helpers, programFuncs }); }).toThrowError(err);
           // prettier-ignore
-          expect(() => { printer({ helpers, programFunc }); }).toThrowErrorMatchingSnapshot();
+          expect(() => { printer({ helpers, programFuncs }); }).toThrowErrorMatchingSnapshot();
         });
       }
     });

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -23,30 +23,6 @@ describe('addUDFHelper', () => {
         // prettier-ignore
         const cases = [
           {
-            method: 'PluginPass#addUDFHelper',
-            preFunc: (pass, helpers) => {
-              try {
-                pass.constructor.prototype.addUDFHelper = function () { };
-                useDangerousUDFHelpers(pass, helpers);
-              } catch (e) {
-                pass.constructor.prototype.addUDFHelper = undefined;
-                throw e
-              }
-            }
-          },
-          {
-            method: 'PluginPass#listUDFHelper',
-            preFunc: (pass, helpers) => {
-              try {
-                pass.constructor.prototype.listUDFHelper = function () { };
-                useDangerousUDFHelpers(pass, helpers);
-              } catch (e) {
-                pass.constructor.prototype.listUDFHelper = undefined;
-                throw e
-              }
-            }
-          },
-          {
             method: 'BabelFile#addUDFHelper',
             preFunc: (pass, helpers) => {
               try {

--- a/src/__tests__/fixtures/basic/dependencies/input.js
+++ b/src/__tests__/fixtures/basic/dependencies/input.js
@@ -4,17 +4,17 @@ const helpers = Object.create(null);
 module.exports = helpers;
 
 helpers.dependencies = helper`
-  import child1 from "child1";
+  import child from "child";
   import child2 from "child2";
 
   export default function _dependencies(){
-    cild1() || child2()
+    child() || child2()
   };
 `;
 
-helpers.child1 = helper`
-  export default function _child1(){
-    return "child1"
+helpers.child = helper`
+  export default function _child(){
+    return "child"
   };
 `;
 

--- a/src/__tests__/fixtures/basic/dependencies/output.js
+++ b/src/__tests__/fixtures/basic/dependencies/output.js
@@ -1,4 +1,4 @@
-function _dependencies() { cild1() || _child2(); }
+function _dependencies() { _child() || _child2(); }
 
 ;
 
@@ -10,6 +10,6 @@ function _grandchild() { return "grandchild"; }
 
 ;
 
-function _child() { return "child1"; }
+function _child() { return "child"; }
 
 ;

--- a/src/__tests__/printer/index.ts
+++ b/src/__tests__/printer/index.ts
@@ -6,19 +6,21 @@ import { ProgramFunc, PreFunc } from './types';
 
 type Printer = {
   helpers: UDFHelpers;
-  programFunc: ProgramFunc;
+  programFuncs: ProgramFunc[];
   preFunc?: PreFunc;
   content?: string;
 };
 
-export default function printer({ helpers, programFunc, content, preFunc }: Printer) {
+export default function printer({ helpers, programFuncs, preFunc, content }: Printer) {
   const ast: any = parser.parse(content || '', {
     sourceType: 'module',
   });
 
-  const plugin = createBabelPlugin(helpers, programFunc, preFunc);
+  const plugins = programFuncs.map((programFunc, index) =>
+    createBabelPlugin(helpers, programFunc, index, preFunc)
+  );
   const { code } = transformFromAstSync(ast, undefined, {
-    plugins: [plugin],
+    plugins,
   }) as babel.BabelFileResult;
 
   return code;

--- a/src/__tests__/printer/plugin.ts
+++ b/src/__tests__/printer/plugin.ts
@@ -5,6 +5,7 @@ import { useDangerousUDFHelpers, UDFHelpers } from '../../';
 export default function createBabelPlugin(
   helpers: UDFHelpers,
   programFunc: ProgramFunc,
+  index: number,
   preFunc?: PreFunc
 ) {
   // prettier-ignore
@@ -12,7 +13,7 @@ export default function createBabelPlugin(
 
   return function ({ types: t }: BabelTypes) {
     return {
-      name: 'babel-udf-helpers-test',
+      name: `babel-udf-helpers-test-${index}`,
       pre() {
         preFunc(this, helpers);
       },

--- a/src/core_ext/index.ts
+++ b/src/core_ext/index.ts
@@ -9,17 +9,74 @@ export default function useDangerousUDFHelpers(pass: babel.PluginPass, opts: UDF
   if (
     // @ts-ignore
     typeof pass.file['addUDFHelper'] === 'function' ||
-    typeof pass['addUDFHelper'] === 'function' ||
     // @ts-ignore
-    typeof pass.file['listUDFHelper'] === 'function' ||
-    typeof pass['listUDFHelper'] === 'function'
-  )
-    throw new AlreadyImplementedError(`
+    typeof pass.file['listUDFHelper'] === 'function'
+  ) {
+    // @ts-ignore
+    if (!pass.file['__use_babel_udf_helpers__']) {
+      throw new AlreadyImplementedError(`
 This tool cannot be used. officially supported.
 Please see the official documentation.
 https://babeljs.io/docs/en/babel-helpers
 `);
+    } else {
+      /**
+       * MEMO:
+       *
+       * It will be redined for pass.file,
+       * but it is not stored in pass, so substitute
+       *
+       * Perhaps behaviorally,
+       * a new instance of babel.PluginPass will be updated for each plugin,
+       * but babel.BabelFile behaves like being reused.
+       *
+       */
+      defineUDFHelpersFuncForPluginPass(pass);
+      return;
+    }
+  } else {
+    setHelpersInStore(opts);
 
+    Object.defineProperty(pass.file, '__use_babel_udf_helpers__', {
+      enumerable: true,
+      value: true,
+    });
+
+    Object.defineProperty(pass.file, 'addUDFHelper', {
+      enumerable: true,
+      get: function addUDFHelper() {
+        return _file.addUDFHelper.bind(pass.file);
+      },
+    });
+
+    Object.defineProperty(pass.file, 'listUDFHelper', {
+      enumerable: true,
+      get: function listUDFHelper() {
+        return _file.listUDFHelper.bind(pass.file);
+      },
+    });
+
+    defineUDFHelpersFuncForPluginPass(pass);
+  }
+}
+
+function defineUDFHelpersFuncForPluginPass(pass: babel.PluginPass): void {
+  Object.defineProperty(pass, 'addUDFHelper', {
+    enumerable: true,
+    get: function addUDFHelper() {
+      return pass.file['addUDFHelper'];
+    },
+  });
+
+  Object.defineProperty(pass, 'listUDFHelper', {
+    enumerable: true,
+    get: function addUDFHelper() {
+      return pass.file['listUDFHelper'];
+    },
+  });
+}
+
+function setHelpersInStore(opts: UDFUsePluginOptions): void {
   const helpers = opts['helpers'];
   if (helpers) {
     /**
@@ -32,32 +89,4 @@ https://babeljs.io/docs/en/babel-helpers
   } else {
     throw new NotFoundError('Not found UDF helpers.');
   }
-
-  Object.defineProperty(pass.file, 'addUDFHelper', {
-    enumerable: true,
-    get: function addUDFHelper() {
-      return _file.addUDFHelper.bind(pass.file);
-    },
-  });
-
-  Object.defineProperty(pass, 'addUDFHelper', {
-    enumerable: true,
-    get: function addUDFHelper() {
-      return _file.addUDFHelper.bind(pass.file);
-    },
-  });
-
-  Object.defineProperty(pass.file, 'listUDFHelper', {
-    enumerable: true,
-    get: function listUDFHelper() {
-      return _file.listUDFHelper.bind(pass.file);
-    },
-  });
-
-  Object.defineProperty(pass, 'listUDFHelper', {
-    enumerable: true,
-    get: function listUDFHelper() {
-      return _file.listUDFHelper.bind(pass.file);
-    },
-  });
 }


### PR DESCRIPTION
## Summary

Fix #20 

- When using multiple plugins, the instance of PluginPass will be newly updated and the instance of BabelFile will be reused, 
so we fixed it accordingly.
- Add test about using multi plugins

## Test

I know the cause of the test failure in jest running in parallel

Related to this issue #19 

```
$ yarn test
yarn run v1.19.0
$ jest
(node:6321) ExperimentalWarning: The fs.promises API is experimental
(node:6322) ExperimentalWarning: The fs.promises API is experimental
 PASS  src/__tests__/error.test.ts
 FAIL  src/__tests__/basic.test.ts
  ● addUDFHelper › basic › multi plugins

    TypeError: unknown: Cannot read property 'body' of undefined

      43 |       const exportNode = path.get(iExportPath) as NodePath;
      44 |       const importPaths = iImportPaths.map((p) => path.get(p));
    > 45 |       const importBindingRefs = iImportBindingsReferences.map((p) => path.get(p));
         |                                                                           ^
      46 |
      47 |       const declar = exportNode.get('declaration') as NodePath;
      48 |       if (currentId.type === 'Identifier') {

      at NodePath._getKey (node_modules/@babel/traverse/lib/path/family.js:178:25)
      at NodePath.get (node_modules/@babel/traverse/lib/path/family.js:170:17)
      at NodePath._getPattern (node_modules/@babel/traverse/lib/path/family.js:210:21)
      at NodePath.get (node_modules/@babel/traverse/lib/path/family.js:172:17)
      at Program.iImportBindingsReferences.map (src/builder/plugins/ProgramBuild.ts:45:75)
          at Array.map (<anonymous>)
      at Program (src/builder/plugins/ProgramBuild.ts:45:59)
      at NodePath._call (node_modules/@babel/traverse/lib/path/context.js:55:20)
      at NodePath.call (node_modules/@babel/traverse/lib/path/context.js:42:17)
      at NodePath.visit (node_modules/@babel/traverse/lib/path/context.js:90:31)
      at TraversalContext.visitQueue (node_modules/@babel/traverse/lib/context.js:112:16)
      at TraversalContext.visitSingle (node_modules/@babel/traverse/lib/context.js:84:19)
      at TraversalContext.visit (node_modules/@babel/traverse/lib/context.js:140:19)
      at Function.traverse.node (node_modules/@babel/traverse/lib/index.js:84:17)
      at Object.traverse [as default] (node_modules/@babel/traverse/lib/index.js:66:12)
      at Object.ProgramBuild (src/builder/plugins/ProgramBuild.ts:132:11)
      at Object.build (src/builder/index.ts:71:9)
      at Object.buildProgram (src/builder/index.ts:100:27)
      at File.addUDFHelper (src/core_ext/file.ts:42:38)
      at File.addUDFHelper (src/core_ext/file.ts:39:30)
      at programFuncs (src/__tests__/basic.test.ts:49:44)
      at PluginPass.Program (src/__tests__/printer/plugin.ts:22:11)
      at newFn (node_modules/@babel/traverse/lib/visitors.js:179:21)
      at NodePath._call (node_modules/@babel/traverse/lib/path/context.js:55:20)
      at NodePath.call (node_modules/@babel/traverse/lib/path/context.js:42:17)
      at NodePath.visit (node_modules/@babel/traverse/lib/path/context.js:90:31)
      at TraversalContext.visitQueue (node_modules/@babel/traverse/lib/context.js:112:16)
      at TraversalContext.visitSingle (node_modules/@babel/traverse/lib/context.js:84:19)
      at TraversalContext.visit (node_modules/@babel/traverse/lib/context.js:140:19)
      at Function.traverse.node (node_modules/@babel/traverse/lib/index.js:84:17)
      at traverse (node_modules/@babel/traverse/lib/index.js:66:12)
      at transformFile (node_modules/@babel/core/lib/transformation/index.js:107:29)
          at transformFile.next (<anonymous>)
      at run (node_modules/@babel/core/lib/transformation/index.js:35:12)
          at run.next (<anonymous>)
      at Object.<anonymous> (node_modules/@babel/core/lib/transform-ast.js:28:41)
      at evaluateSync (node_modules/gensync/index.js:244:28)
      at Object.sync (node_modules/gensync/index.js:84:14)
      at Object.printer (src/__tests__/printer/index.ts:22:20)
      at Object.test (src/__tests__/basic.test.ts:51:27)

Test Suites: 1 failed, 1 passed, 2 total
Tests:       1 failed, 15 passed, 16 total
Snapshots:   15 passed, 15 total
Time:        2.096 s, estimated 3 s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Single execution is possible

```
$ yarn test -t "multi plugins"
yarn run v1.19.0
$ jest -t 'multi plugins'
(node:6439) ExperimentalWarning: The fs.promises API is experimental
(node:6440) ExperimentalWarning: The fs.promises API is experimental
 PASS  src/__tests__/basic.test.ts

Test Suites: 1 skipped, 1 passed, 1 of 2 total
Tests:       15 skipped, 1 passed, 16 total
Snapshots:   1 passed, 1 total
Time:        2.252 s
Ran all test suites with tests matching "multi plugins".
✨  Done in 3.90s.
```