### PR TITLE
Fix bugs when execute parallel

### DIFF
--- a/src/__tests__/basic.test.ts
+++ b/src/__tests__/basic.test.ts
@@ -46,7 +46,7 @@ describe('addUDFHelper', () => {
     test('multi plugins', () => {
       const dir = 'dependencies';
       const helpers = require(inputFixturePath([type, dir]));
-      const programFuncs = [(pass) => pass.addUDFHelper(dir)];
+      const programFuncs = [(pass) => pass.addUDFHelper(dir), (pass) => pass.addUDFHelper(dir)];
       // @ts-ignore
       const code = printer({ helpers, programFuncs });
 


### PR DESCRIPTION
## Summary

Resolve #19 

The builderHelper bypass has to be initialized for each traverse, 
but the opts parameter in the builderHelper instance had to be inherited.

## Test

```
$ yarn test
yarn run v1.19.0
$ jest
(node:15358) ExperimentalWarning: The fs.promises API is experimental
(node:15357) ExperimentalWarning: The fs.promises API is experimental
 PASS  src/__tests__/basic.test.ts
 PASS  src/__tests__/error.test.ts

Test Suites: 2 passed, 2 total
Tests:       16 passed, 16 total
Snapshots:   16 passed, 16 total
Time:        2.124 s, estimated 3 s
Ran all test suites.
✨  Done in 3.33s.
```
