### PR TITLE
Fix Helper loading/helper name duplication problem

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -45,7 +45,7 @@ The return type is `t.Identifier`.
 ### definition
 
 ```ts
-addUDFHelper(name: string): t.Identifier
+addUDFHelper(name: string): t.Identifier | Array<t.Identifier>
 ```
 
 ### example
@@ -53,11 +53,17 @@ addUDFHelper(name: string): t.Identifier
 ```ts
 visitor: {
   Program(path){
-    // e.g.) identifier is { type: 'identifier', name: '_programHelper' }
+    // e.g.) identifier is { type: 'Identifier', name: '_programHelper' }
+    // e.g.) identifier is [{ type: 'Identifier', name: '_programHelper' }, { type: 'Identifier', name: '_programHelper2' }]
     const identifier = this.addUDFHelper("programHelper")
   }
 }
 ```
+
+::: danger Remark
+If the result comes back in an array, it means that a helper with the same name is defined between plugins.
+We recommend changing the name of the helper if possible.
+:::
 
 ## listUDFHelper
 

--- a/src/__tests__/__snapshots__/basic.test.ts.snap
+++ b/src/__tests__/__snapshots__/basic.test.ts.snap
@@ -21,7 +21,23 @@ function _child() { return \\"child\\"; }
 `;
 
 exports[`addUDFHelper basic multi plugins 1`] = `
-"function _dependencies() { _child() || _child2(); }
+"function _dependencies2() { _child3() || _child4(); }
+
+;
+
+function _child4() { _grandchild2(); }
+
+;
+
+function _grandchild2() { return \\"grandchild\\"; }
+
+;
+
+function _child3() { return \\"child\\"; }
+
+;
+
+function _dependencies() { _child() || _child2(); }
 
 ;
 
@@ -37,6 +53,8 @@ function _child() { return \\"child\\"; }
 
 ;"
 `;
+
+exports[`addUDFHelper basic multi plugins 2`] = `"UDF helper: 'dependencies' is used in babel-udf-helpers-test-0, babel-udf-helpers-test-1"`;
 
 exports[`addUDFHelper basic rename 1`] = `
 "function _rename2() { console.log(\\"rename\\"); }

--- a/src/__tests__/__snapshots__/error.test.ts.snap
+++ b/src/__tests__/__snapshots__/error.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`addUDFHelper error DependencyResolvePlugin doNotExist 1`] = `"unknown: Unknown helper doNotExist"`;
+exports[`addUDFHelper error DependencyResolvePlugin doNotExist 1`] = `"unknown: Unknown UDF helper doNotExist"`;
 
 exports[`addUDFHelper error DependencyResolvePlugin doNotExportDefault 1`] = `"unknown: UDF Helpers must default-export something."`;
 

--- a/src/__tests__/basic.test.ts
+++ b/src/__tests__/basic.test.ts
@@ -51,6 +51,7 @@ describe('addUDFHelper', () => {
       const code = printer({ helpers, programFuncs });
 
       expect(code).toMatchSnapshot();
+      expect((console.warn as jest.Mock).mock.calls[0][0]).toMatchSnapshot();
       writeFile(outputFixturePath([type, dir]), code || '', () => {});
     });
   });

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -92,7 +92,7 @@ https://babeljs.io/docs/en/babel-helpers
     describe('DependencyResolvePlugin', () => {
       // prettier-ignore
       const cases = [
-        { dir: 'doNotExist', err: new ReferenceError('unknown: Unknown helper doNotExist') },
+        { dir: 'doNotExist', err: new ReferenceError('unknown: Unknown UDF helper doNotExist') },
         { dir: 'importNamed', err: new SyntaxError('unknown: UDF Helpers can only import a default value (This is an error on an internal node. Probably an internal error.)') },
         { dir: 'doNotGiveName', err: new SyntaxError('unknown: UDF Helpers should give names to their exported func declaration (This is an error on an internal node. Probably an internal error.)') },
         { dir: 'expression', err: new SyntaxError('unknown: UDF Helpers must be a function declaration (This is an error on an internal node. Probably an internal error.)') },

--- a/src/__tests__/fixtures/basic/dependencies/output.js
+++ b/src/__tests__/fixtures/basic/dependencies/output.js
@@ -1,3 +1,19 @@
+function _dependencies2() { _child3() || _child4(); }
+
+;
+
+function _child4() { _grandchild2(); }
+
+;
+
+function _grandchild2() { return "grandchild"; }
+
+;
+
+function _child3() { return "child"; }
+
+;
+
 function _dependencies() { _child() || _child2(); }
 
 ;

--- a/src/builder/plugins/DependencyResolve.ts
+++ b/src/builder/plugins/DependencyResolve.ts
@@ -5,14 +5,14 @@ import { helpers as helpersStore } from '../../store';
 
 export default function DependencyResolve(file: babel.BabelFile, options?: UDFPluginOptions): void {
   const { opts } = file;
-  const { iDependencies, iImportPaths } = opts as any;
+  const { iDependencies, iImportPaths, iPluginName } = opts as any;
 
   const visitor = {
     ImportDeclaration(path: NodePath) {
       // @ts-ignore
       const name = path.node.source.value;
 
-      if (!helpersStore[name]) {
+      if (!helpersStore[iPluginName][name]) {
         throw new ReferenceError(`Unknown UDF helper ${name}`);
       }
 

--- a/src/core_ext/index.ts
+++ b/src/core_ext/index.ts
@@ -31,6 +31,7 @@ https://babeljs.io/docs/en/babel-helpers
        * but babel.BabelFile behaves like being reused.
        *
        */
+      setHelpersInStore(opts);
       defineUDFHelpersFuncForPluginPass(pass);
       return;
     }

--- a/src/core_ext/index.ts
+++ b/src/core_ext/index.ts
@@ -31,12 +31,12 @@ https://babeljs.io/docs/en/babel-helpers
        * but babel.BabelFile behaves like being reused.
        *
        */
-      setHelpersInStore(opts);
+      setHelpersInStore(pass, opts);
       defineUDFHelpersFuncForPluginPass(pass);
       return;
     }
   } else {
-    setHelpersInStore(opts);
+    setHelpersInStore(pass, opts);
 
     Object.defineProperty(pass.file, '__use_babel_udf_helpers__', {
       enumerable: true,
@@ -77,7 +77,7 @@ function defineUDFHelpersFuncForPluginPass(pass: babel.PluginPass): void {
   });
 }
 
-function setHelpersInStore(opts: UDFUsePluginOptions): void {
+function setHelpersInStore(pass, opts: UDFUsePluginOptions): void {
   const helpers = opts['helpers'];
   if (helpers) {
     /**
@@ -86,7 +86,10 @@ function setHelpersInStore(opts: UDFUsePluginOptions): void {
      * import * as helpers from './helpers'
      * import helpers from './helpers'
      */
-    Object.assign(helpersStore, helpers.default ? helpers.default : helpers);
+    const namespacedHelpers = {
+      [pass.key]: helpers.default ? helpers.default : helpers,
+    };
+    Object.assign(helpersStore, namespacedHelpers);
   } else {
     throw new NotFoundError('Not found UDF helpers.');
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,9 @@ export type UDFHelper = {
   ast: () => t.Program;
 };
 export type UDFHelpers = {
-  [key: string]: UDFHelper;
+  [key: string]: {
+    [key: string]: UDFHelper;
+  };
 };
 export type UDFHelperList = {
   available: string[];


### PR DESCRIPTION
## Summary

Fix #30 #31 

## Test

```
$ yarn test --verbose
yarn run v1.19.0
$ jest --verbose
 PASS  src/__tests__/error.test.ts
  addUDFHelper
    error
      core_ext
        ✓ Not found UDF helpers (1 ms)
        ✓ babelAlreadyDefined (28 ms)
        babelImplemented
          ✓ BabelFile#addUDFHelper (33 ms)
          ✓ BabelFile#listUDFHelper (2 ms)
      DependencyResolvePlugin
        ✓ doNotExist (4 ms)
        ✓ importNamed (6 ms)
        ✓ doNotGiveName (5 ms)
        ✓ expression (6 ms)
        ✓ exportAll (5 ms)
        ✓ exportNamed (5 ms)
        ✓ doNotExportDefault (5 ms)

 PASS  src/__tests__/basic.test.ts
  addUDFHelper
    basic
      ✓ declaration (33 ms)
      ✓ dependencies (12 ms)
      ✓ rename (7 ms)
      ✓ multi plugins (14 ms)
  listUDFHelper
    basic
      ✓ officialMix (14 ms)

Test Suites: 2 passed, 2 total
Tests:       16 passed, 16 total
Snapshots:   17 passed, 17 total
Time:        1.947 s
Ran all test suites.
✨  Done in 2.88s.
```